### PR TITLE
Add GitHub Action to release multiarch image

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -1,0 +1,30 @@
+name: buildx
+on:
+  push:
+    branches:
+      - master
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6,linux/386
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6,linux/386
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/h5ai:latest
+          push: true


### PR DESCRIPTION
This adds a very basic GitHub Action that builds an image of h5ai for the architectures `linux/amd64` , `linux/arm64`, `linux/arm/v7`, `linux/arm/v6`, and `linux/386` upon pushing to the `master` branch.

This just requires two secrets to be added to the repository:
* `DOCKERHUB_USERNAME` - this is `awesometic` in your case
* `DOCKERHUB_PASSWORD` - this is an access token you can generate from Docker Hub at `Account Settings > Security > Access Tokens`

Sample run: https://github.com/b-ggs/docker-h5ai/runs/1927113619?check_suite_focus=true
Resulting image: https://hub.docker.com/layers/bxggs/h5ai/latest/images/sha256-f55e4aaef623edf1f4933d376afd31079afa2d7b3a6716c19d5c6d093829cba7?context=repo

Closes #4 