### PR TITLE
Update Nginx version to 1.22.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.21.6-alpine
+FROM nginx:1.22.0-alpine
 LABEL maintainer="Deokgyu Yang <secugyu@gmail.com>" \
       description="Lightweight h5ai 0.30.0 container with Nginx 1.21 & PHP 8 based on Alpine Linux."
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ And I do choose Nginx-Alpine to get the benefits from some tweaks of Nginx versi
 
 So this is composed of,
 
-* Alpine Linux 3.15
-* Nginx 1.21.6
-* PHP 8.0.14
+* Alpine Linux 3.16
+* Nginx 1.22.0
+* PHP 8.0.19
 
 with,
 


### PR DESCRIPTION
Hello hello!

This upgrades:
- Nginx to `1.22.0` (from `1.21.6`)
- PHP to  `8.0.19` (from `8.0.14`)
- Alpine to `3.16` (from `3.15`)

Seems to be good and not cause any problems from my testing and usage anyway :)