### PR TITLE
Update Nginx version to 1.23.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.22.0-alpine
+FROM nginx:1.23.0-alpine
 LABEL maintainer="Deokgyu Yang <secugyu@gmail.com>" \
       description="Lightweight h5ai 0.30.0 container with Nginx 1.21 & PHP 8 based on Alpine Linux."
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ So this is composed of,
 
 * Alpine Linux 3.16
 * Nginx 1.22.0
-* PHP 8.0.19
+* PHP 8.0.20
 
 with,
 


### PR DESCRIPTION
Hihi! 

I wonder why they released 1.23.0 only a month after 1.22.0 with nothing in-between...

This also upgraded PHP to 8.0.20 (from 8.0.19)

Looks to be good from my testing but as always I can't guarantee it!